### PR TITLE
Adding newExpOffByDefault feature (server side)

### DIFF
--- a/lib/controllers/api/coupling.js
+++ b/lib/controllers/api/coupling.js
@@ -26,13 +26,14 @@
   function couplingHandler(req, res, next) {
     var devKey = req.headers['x-feature-key']
       , devKeyShared = req.headers['x-feature-key-shared']
+      , newExpOffByDefault = req.headers['x-feature-default-exp-off']
       , expList = req.body.experiments
       , shared = req.body.shared
       , promises = [];
 
     if (! devKey) return res.send(401);
 
-    promises[0] = announceAndUpdate({ dev_key: devKey }, expList);
+    promises[0] = announceAndUpdate({ dev_key: devKey }, expList, newExpOffByDefault);
 
     if (devKeyShared) {
       if (! shared) shared = {};
@@ -53,7 +54,7 @@
     });
   }
 
-  function announceAndUpdate(fetcher, expList) {
+  function announceAndUpdate(fetcher, expList, newExpOffByDefault) {
     var dfd = Q.defer();
 
     AppModel.findOne(fetcher)
@@ -75,15 +76,15 @@
         });
 
         var newList = expList.filter(function(item) {
-            var curr = oldObj[item.name];
-            if (! curr) return true;
+          var curr = oldObj[item.name];
+          if (! curr) return true;
 
-            if (item.description && item.description !== curr.description) {
-              descriptionList.push({ id: curr._id, description: item.description });
-            }
+          if (item.description && item.description !== curr.description) {
+            descriptionList.push({ id: curr._id, description: item.description });
+          }
 
-            return false;
-          });
+          return false;
+        });
 
         var edited = false;
 
@@ -92,7 +93,7 @@
 
         newList.map(function(item) {
           var exp = new ExpModel(item);
-          if (item.default) exp.value = item.default;
+          if (item.default) exp.value = (newExpOffByDefault) ? false : item.default;
           doc.experiments.push(exp);
           edited = true;
         });

--- a/lib/controllers/api/coupling.js
+++ b/lib/controllers/api/coupling.js
@@ -26,7 +26,7 @@
   function couplingHandler(req, res, next) {
     var devKey = req.headers['x-feature-key']
       , devKeyShared = req.headers['x-feature-key-shared']
-      , newExpOffByDefault = req.headers['x-feature-default-exp-off']
+      , newExpOffByDefault = req.headers['x-feature-default-exp-off'] === 'true' //Convert to boolean
       , expList = req.body.experiments
       , shared = req.body.shared
       , promises = [];
@@ -37,7 +37,7 @@
 
     if (devKeyShared) {
       if (! shared) shared = {};
-      promises[1] = announceAndUpdate({ dev_key: devKeyShared }, shared.experiments);
+      promises[1] = announceAndUpdate({ dev_key: devKeyShared }, shared.experiments, newExpOffByDefault);
     }
 
     Q.all(promises).then(function(results) {
@@ -93,7 +93,7 @@
 
         newList.map(function(item) {
           var exp = new ExpModel(item);
-          if (item.default) exp.value = (newExpOffByDefault) ? false : item.default;
+          if (item.default) exp.value = newExpOffByDefault ? false : item.default;
           doc.experiments.push(exp);
           edited = true;
         });


### PR DESCRIPTION
This new 'newExpOffByDefault' setting defaults the experiment state to OFF for new experiments. 

By default, this new settings is set to **`false`** (which is mimics the current behavior). This feature is turned on by explicitly setting this to **`true`** in the settings passed into the feature-client (such as "featureConfig").

This setting is passed from the _feature-client_ and then experiment value is set accordingly.

_(see https://github.com/XPRMNTL/feature-client.js/pull/1 )_
