### PR TITLE
Use an environment variable to control ability to set new experiment default value.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ Required environment variables:
   - A comma-separated (no spaces) list of Github Organizations from which to pull repos for experiments
   - Example: "heroku,github,something"
 
+Optional environment variables:
+- `ALLOW_NEW_EXP_DEFAULT`
+  - A boolean value which determines if client apps are allowed to set the default value for new experiments
+  - Default: false
 
 ## API Documentation
 There are two endpoint groups of the API. There are the Dashboard endpoints, which are used internally by this dashboard, and the Coupling endpoint, which is what your experimenting apps will use.

--- a/lib/controllers/api/coupling.js
+++ b/lib/controllers/api/coupling.js
@@ -92,7 +92,13 @@
 
         newList.map(function(item) {
           var exp = new ExpModel(item);
-          if (item.default) exp.value = item.default;
+
+          /* The model sets the experiment value to false by default, so only worry about setting it if
+           * the feature service is configured to allow apps to set the default for new experiments. */
+          if (allowNewExpDefault() && item.default) {
+            exp.value = item.default;
+          }
+
           doc.experiments.push(exp);
           edited = true;
         });
@@ -120,6 +126,22 @@
       });
 
     return dfd.promise;
+  }
+
+  /**
+   * Determines if the environment variable ALLOW_NEW_EXP_DEFAULT is set to allow client apps to set the default
+   * value for new experiments.
+   *
+   * @returns {boolean}
+   */
+  function allowNewExpDefault() {
+    var allow = false
+      , allowEnv = process.env.ALLOW_NEW_EXP_DEFAULT;
+
+    if (allowEnv && allowEnv.toLowerCase() === 'true') {
+      allow = true;
+    }
+    return allow;
   }
 
 })();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feature",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Experiments Dashboard for Frontier",
   "main": "app.js",
   "author": "Dan Crews <crewsd@gmail.com>",

--- a/test/mocks.json
+++ b/test/mocks.json
@@ -172,6 +172,16 @@
         "envs": {}
       }
     },
+    "simpleNoDefault": {
+      "app": {
+        "experiments": {
+          "testExp1": false,
+          "testExp2": false
+        },
+        "groups": {},
+        "envs": {}
+      }
+    },
     "simpleShared" : {
       "app": {
         "experiments": {

--- a/test/server/api/coupling/basic.test.js
+++ b/test/server/api/coupling/basic.test.js
@@ -82,23 +82,57 @@ describe('API Coupling interface (/api/coupling) for basic configurations:', fun
       });
     });
 
-    it('should add all data and send back defaulted configs', function(done) {
+    describe('Given a simple experiments list with ALLOW_NEW_EXP_DEFAULT set to false, ', function () {
+      before(function(done) {
+        process.env.ALLOW_NEW_EXP_DEFAULT = 'false';
+        done();
+      });
 
-      supertest.agent(app)
-        .post(ENDPOINT)
-        .set({
-          'x-feature-key': devKey
-        })
-        .send(mocks.raw.simple)
-        .expect(200, function(err, resp) {
-          if (err) return done(err);
+      it('should add all data and send back defaulted configs with all defaults set to false', function (done) {
 
-          expect(resp.body).to.eql(mocks.api.simple);
-          done();
-        });
+        supertest.agent(app)
+          .post(ENDPOINT)
+          .set({
+            'x-feature-key': devKey
+          })
+          .send(mocks.raw.simple)
+          .expect(200, function (err, resp) {
+            if (err) return done(err);
 
+            expect(resp.body).to.eql(mocks.api.simpleNoDefault);
+            done();
+          });
+      });
     });
 
+    describe('Given a simple experiments list with ALLOW_NEW_EXP_DEFAULT set to true, ', function () {
+      before(function(done) {
+        process.env.ALLOW_NEW_EXP_DEFAULT = 'true';
+        done();
+      });
+
+      after(function(done) {
+        process.env.ALLOW_NEW_EXP_DEFAULT = 'false';
+        done();
+      });
+
+      it('should add all data and send back defaulted configs', function (done) {
+
+        supertest.agent(app)
+          .post(ENDPOINT)
+          .set({
+            'x-feature-key': devKey
+          })
+          .send(mocks.raw.simple)
+          .expect(200, function (err, resp) {
+            if (err) return done(err);
+
+            expect(resp.body).to.eql(mocks.api.simple);
+
+            done();
+          });
+      });
+    });
   });
 
   describe('When fetching experiments, POST(/)', function() {
@@ -106,6 +140,8 @@ describe('API Coupling interface (/api/coupling) for basic configurations:', fun
     var devKey, sharedKey, _docs;
 
     before(function(done) {
+      process.env.ALLOW_NEW_EXP_DEFAULT = 'true';
+
       helpers.createApps([
         { 'github_repo': 'example/example2' },
         { 'github_repo': 'example/shared2' }
@@ -119,13 +155,14 @@ describe('API Coupling interface (/api/coupling) for basic configurations:', fun
     });
 
     after(function(done) {
+      process.env.ALLOW_NEW_EXP_DEFAULT = 'false';
+
       helpers.deleteApps(_docs, function() {
         done();
       });
     });
 
     describe('Given no shared header', function() {
-
       it('should send back all existing experiments', function(done) {
 
         supertest.agent(app)


### PR DESCRIPTION
# Problem space:
- New experiments can potentially be turned on immediately upon being pushed to production.
# Changes:
- [ ] Introduced a new boolean environment variable named ALLOW_NEW_EXP_DEFAULT.
- [ ] Setting the value for new experiments now depends upon ALLOW_NEW_EXP_DEFAULT.
- [ ] Feature service version changed from 0.9.1 to 0.9.2.
# Affects:
- All apps using XPRMNTL.
# Should:
- [ ] Set the value of a new experiment to false if ALLOW_NEW_EXP_DEFAULT is missing.
- [ ] Set the value of a new experiment to false if ALLOW_NEW_EXP_DEFAULT is set to false.
- [ ] Set the value of a new experiment to the value sent by the client app if ALLOW_NEW_EXP_DEFAULT is set to true.
