### PR TITLE
Experiment validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .DS_Store
 .env
+*.log

--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ Required environment variables:
   - A comma-separated (no spaces) list of Github Organizations from which to pull repos for experiments
   - Example: "heroku,github,something"
 
+Optional environment variables:
+- `ALLOW_NEW_EXP_DEFAULT`
+  - A boolean value which determines if client apps are allowed to set the default value for new experiments
+  - Default: false
 
 ## API Documentation
 There are two endpoint groups of the API. There are the Dashboard endpoints, which are used internally by this dashboard, and the Coupling endpoint, which is what your experimenting apps will use.

--- a/lib/controllers/api/coupling.js
+++ b/lib/controllers/api/coupling.js
@@ -99,7 +99,13 @@
 
         newList.map(function(item) {
           var exp = new ExpModel(item);
-          if (item.default) exp.value = item.default;
+
+          /* The model sets the experiment value to false by default, so only worry about setting it if
+           * the feature service is configured to allow apps to set the default for new experiments. */
+          if (allowNewExpDefault() && item.default) {
+            exp.value = item.default;
+          }
+
           doc.experiments.push(exp);
           edited = true;
         });
@@ -127,6 +133,22 @@
       });
 
     return dfd.promise;
+  }
+
+  /**
+   * Determines if the environment variable ALLOW_NEW_EXP_DEFAULT is set to allow client apps to set the default
+   * value for new experiments.
+   *
+   * @returns {boolean}
+   */
+  function allowNewExpDefault() {
+    var allow = false
+      , allowEnv = process.env.ALLOW_NEW_EXP_DEFAULT;
+
+    if (allowEnv && allowEnv.toLowerCase() === 'true') {
+      allow = true;
+    }
+    return allow;
   }
 
   /**

--- a/lib/controllers/api/coupling.js
+++ b/lib/controllers/api/coupling.js
@@ -5,7 +5,9 @@
    * Module Dependencies
    */
   var debug = require('debug')('feature:api:coupling')
-    , Q = require('q');
+    , Q = require('q')
+    , validationUtil = require('xpr-util-validation')
+    , experimentValidator = validationUtil.experimentValidator;
 
   /**
    * Local Dependencies
@@ -77,8 +79,8 @@
         var newList = expList.filter(function(item) {
             var curr = oldObj[item.name];
             if (! curr) {
-              if (!isValidExperiment(item)) {
-                debug('Invalid experiment not added: ', item);
+              if (!experimentValidator.isValid(item)) {
+                console.warn('Invalid experiment not added: %s', JSON.stringify(item));
                 return false;
               }
               return true;
@@ -126,19 +128,5 @@
       });
 
     return dfd.promise;
-  }
-
-  /**
-   * Checks if the experiment is valid.
-   * @param experiment
-   */
-  function isValidExperiment(experiment) {
-    var valid = false;
-    /* Experiment must have a name and the name cannot contain whitespace chars (space, newline, tab, etc) */
-    if (experiment && experiment.name && !experiment.name.match(/\s/g)) {
-      valid = true;
-    }
-
-    return valid;
   }
 })();

--- a/lib/controllers/api/coupling.js
+++ b/lib/controllers/api/coupling.js
@@ -6,8 +6,7 @@
    */
   var debug = require('debug')('feature:api:coupling')
     , Q = require('q')
-    , validationUtil = require('xpr-util-validation')
-    , experimentValidator = validationUtil.experimentValidator;
+    , experimentValidator = require('xpr-util-validation').experimentValidator;
 
   /**
    * Local Dependencies

--- a/lib/controllers/api/coupling.js
+++ b/lib/controllers/api/coupling.js
@@ -66,7 +66,7 @@
         }
 
         if (! doc) return dfd.reject(401);
-        if (! expList) return dfd.resolve(doc.serialized);
+        if (! expList) return dfd.resolve(serializeAndClean(doc));
 
         var oldObj = {}
           , descriptionList = [];
@@ -112,21 +112,48 @@
           edited = true;
         });
 
-        if (! edited) return dfd.resolve(doc.serialized);
+        if (! edited) return dfd.resolve(serializeAndClean(doc));
 
         process.nextTick(function() {
           doc
             .serialize()
             .then(function(_doc) {
-              return dfd.resolve(_doc.serialized);
+              return dfd.resolve(serializeAndClean(_doc));
             }, function(err) {
               console.info('count#xprmntl.resave.fail=1 error="' + err.message + '" fetcher="' + JSON.stringify(fetcher) + '"');
               return dfd.reject(err);
             });
-        });
+      });
 
       });
 
     return dfd.promise;
+  }
+
+  /**
+   * Serialize the document and remove any invalid experiments.
+   *
+   * @param doc
+   * @returns {*}
+   */
+  function serializeAndClean(doc) {
+    var docSerialized = doc.serialized;
+    docSerialized.experiments = cleanExperimentsObj(docSerialized.experiments);
+    return docSerialized;
+  }
+
+  /**
+   * Cleans the provided experiments object by removing invalid experiments.  The cleaned experiments object is returned.
+   *
+   * @param experimentsObj
+   * @returns {Array.<T>|*}
+   */
+  function cleanExperimentsObj(experimentsObj) {
+    for (var key in experimentsObj) {
+      if (experimentsObj.hasOwnProperty(key) && !experimentValidator.isValid({name: key})) {
+        delete experimentsObj[key];
+      }
+    }
+    return experimentsObj;
   }
 })();

--- a/lib/controllers/api/coupling.js
+++ b/lib/controllers/api/coupling.js
@@ -76,7 +76,13 @@
 
         var newList = expList.filter(function(item) {
             var curr = oldObj[item.name];
-            if (! curr) return true;
+            if (! curr) {
+              if (!isValidExperiment(item)) {
+                debug('Invalid experiment not added: ', item);
+                return false;
+              }
+              return true;
+            }
 
             if (item.description && item.description !== curr.description) {
               descriptionList.push({ id: curr._id, description: item.description });
@@ -122,4 +128,17 @@
     return dfd.promise;
   }
 
+  /**
+   * Checks if the experiment is valid.
+   * @param experiment
+   */
+  function isValidExperiment(experiment) {
+    var valid = false;
+    /* Experiment must have a name and the name cannot contain whitespace chars (space, newline, tab, etc) */
+    if (experiment && experiment.name && !experiment.name.match(/\s/g)) {
+      valid = true;
+    }
+
+    return valid;
+  }
 })();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feature",
-  "version": "0.9.1",
+  "version": "0.9.3",
   "description": "Experiments Dashboard for Frontier",
   "main": "app.js",
   "author": "Dan Crews <crewsd@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "simple-stack-common": "^0.2.3",
     "stylus": "^0.47.1",
     "superagent": "^0.18.1",
-    "superagent-defaults": "^0.1.6"
+    "superagent-defaults": "^0.1.6",
+    "xpr-util-validation": "0.0.1"
   },
   "devDependencies": {
     "chai": "^1.9.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feature",
-  "version": "0.9.3",
+  "version": "0.10.0",
   "description": "Experiments Dashboard for Frontier",
   "main": "app.js",
   "author": "Dan Crews <crewsd@gmail.com>",
@@ -20,7 +20,7 @@
     "stylus": "^0.47.1",
     "superagent": "^0.18.1",
     "superagent-defaults": "^0.1.6",
-    "xpr-util-validation": "git+https://github.com/fs-webdev/xpr-util-validation.js.git#0.0.1"
+    "xpr-util-validation": "^0.0.1"
   },
   "devDependencies": {
     "chai": "^1.9.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "stylus": "^0.47.1",
     "superagent": "^0.18.1",
     "superagent-defaults": "^0.1.6",
-    "xpr-util-validation": "0.0.1"
+    "xpr-util-validation": "git+https://github.com/fs-webdev/xpr-util-validation.js.git#0.0.1"
   },
   "devDependencies": {
     "chai": "^1.9.2",

--- a/test/mocks.json
+++ b/test/mocks.json
@@ -147,6 +147,13 @@
         { "name": "testExp2", "default": false }
       ]
     },
+    "simpleInvalid": {
+      "experiments" : [
+        { "name": "testExp1", "default": true },
+        { "name": "testExp2", "default": false },
+        { "name": "test Exp3", "default": false }
+      ]
+    },
     "simpleShared": {
       "experiments" : [
         { "name": "testExp1", "default": true },

--- a/test/mocks.json
+++ b/test/mocks.json
@@ -179,6 +179,16 @@
         "envs": {}
       }
     },
+    "simpleNoDefault": {
+      "app": {
+        "experiments": {
+          "testExp1": false,
+          "testExp2": false
+        },
+        "groups": {},
+        "envs": {}
+      }
+    },
     "simpleShared" : {
       "app": {
         "experiments": {

--- a/test/server/api/coupling/basic.test.js
+++ b/test/server/api/coupling/basic.test.js
@@ -82,6 +82,24 @@ describe('API Coupling interface (/api/coupling) for basic configurations:', fun
       });
     });
 
+    describe('Given an experiments list with any invalid experiments, ', function() {
+
+      it('should reply with an experiments list with invalid experiments removed', function(done) {
+        supertest.agent(app)
+          .post(ENDPOINT)
+          .set({
+            'x-feature-key': devKey
+          })
+          .send(mocks.raw.simpleInvalid)
+          .expect(200, function(err, resp) {
+            if (err) return done(err);
+
+            expect(resp.body).to.eql(mocks.api.simple);
+            done();
+          });
+      });
+    });
+
     it('should add all data and send back defaulted configs', function(done) {
 
       supertest.agent(app)

--- a/test/server/api/coupling/basic.test.js
+++ b/test/server/api/coupling/basic.test.js
@@ -100,23 +100,57 @@ describe('API Coupling interface (/api/coupling) for basic configurations:', fun
       });
     });
 
-    it('should add all data and send back defaulted configs', function(done) {
+    describe('Given a simple experiments list with ALLOW_NEW_EXP_DEFAULT set to false, ', function () {
+      before(function(done) {
+        process.env.ALLOW_NEW_EXP_DEFAULT = 'false';
+        done();
+      });
 
-      supertest.agent(app)
-        .post(ENDPOINT)
-        .set({
-          'x-feature-key': devKey
-        })
-        .send(mocks.raw.simple)
-        .expect(200, function(err, resp) {
-          if (err) return done(err);
+      it('should add all data and send back defaulted configs with all defaults set to false', function (done) {
 
-          expect(resp.body).to.eql(mocks.api.simple);
-          done();
-        });
+        supertest.agent(app)
+          .post(ENDPOINT)
+          .set({
+            'x-feature-key': devKey
+          })
+          .send(mocks.raw.simple)
+          .expect(200, function (err, resp) {
+            if (err) return done(err);
 
+            expect(resp.body).to.eql(mocks.api.simpleNoDefault);
+            done();
+          });
+      });
     });
 
+    describe('Given a simple experiments list with ALLOW_NEW_EXP_DEFAULT set to true, ', function () {
+      before(function(done) {
+        process.env.ALLOW_NEW_EXP_DEFAULT = 'true';
+        done();
+      });
+
+      after(function(done) {
+        process.env.ALLOW_NEW_EXP_DEFAULT = 'false';
+        done();
+      });
+
+      it('should add all data and send back defaulted configs', function (done) {
+
+        supertest.agent(app)
+          .post(ENDPOINT)
+          .set({
+            'x-feature-key': devKey
+          })
+          .send(mocks.raw.simple)
+          .expect(200, function (err, resp) {
+            if (err) return done(err);
+
+            expect(resp.body).to.eql(mocks.api.simple);
+
+            done();
+          });
+      });
+    });
   });
 
   describe('When fetching experiments, POST(/)', function() {
@@ -124,6 +158,8 @@ describe('API Coupling interface (/api/coupling) for basic configurations:', fun
     var devKey, sharedKey, _docs;
 
     before(function(done) {
+      process.env.ALLOW_NEW_EXP_DEFAULT = 'true';
+
       helpers.createApps([
         { 'github_repo': 'example/example2' },
         { 'github_repo': 'example/shared2' }
@@ -137,13 +173,14 @@ describe('API Coupling interface (/api/coupling) for basic configurations:', fun
     });
 
     after(function(done) {
+      process.env.ALLOW_NEW_EXP_DEFAULT = 'false';
+
       helpers.deleteApps(_docs, function() {
         done();
       });
     });
 
     describe('Given no shared header', function() {
-
       it('should send back all existing experiments', function(done) {
 
         supertest.agent(app)

--- a/test/server/api/coupling/basic.test.js
+++ b/test/server/api/coupling/basic.test.js
@@ -83,6 +83,15 @@ describe('API Coupling interface (/api/coupling) for basic configurations:', fun
     });
 
     describe('Given an experiments list with any invalid experiments, ', function() {
+      before(function(done) {
+        process.env.ALLOW_NEW_EXP_DEFAULT = 'true';
+        done();
+      });
+
+      after(function(done) {
+        process.env.ALLOW_NEW_EXP_DEFAULT = 'false';
+        done();
+      });
 
       it('should reply with an experiments list with invalid experiments removed', function(done) {
         supertest.agent(app)


### PR DESCRIPTION
# Problem space:
- Experiment names are not being validated.
# Changes:
- [ ] Pinned to version 0.0.1 of the new xpr-util-validation module for experiment validation.
- [ ] Use the experiment validator to prevent invalid experiments from being persisted in the DB.
- [ ] Use the experiment validator to prevent invalid experiments that exist in the DB from being sent back to the client.
- [ ] Feature service version changed from 0.9.2 to 0.10.0.
- [ ] Changes from PR #3 are already merged.
# Should:
- [ ] Not allow any invalid new experiments sent in by a client to be persisted in the DB.
- [ ] Not allow any invalid experiments read from the DB to be returned back to the client.
